### PR TITLE
add configuration for developer tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,15 @@
 # invenio-edugain is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Invenio extension for login via edugain."""
+root = true
 
-__version__ = "0.0.1"
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
 
-__all__ = ("__version__",)
+# Python files
+[*.py]
+indent_size = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,11 @@
-#
-# pyproject.toml base fields
-#
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-# important fields:
-dynamic = ["version"]  # these are dynamically computed by build-backend
+dynamic = ["version"]
 description = "Invenio extension for login via edugain."
 name = "invenio-edugain"
-# other fields, alphabetically:
 authors = [
   {name = "Graz University of Technology", email = "info@tugraz.at"},
 ]
@@ -25,17 +20,36 @@ keywords = ["invenio", "edugain"]
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.12"
-# `dependencies` field:
 dependencies = []
 
 [project.urls]
 Repository = "https://github.com/tu-graz-library/invenio-edugain"
 
-#
-# tool.setuptools
-#
+
+[tool.isort]
+profile = "black"
+
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+  "D203", "D211", "D212", "D213",
+  "E501",
+  "FA100", "FA102",
+  "FIX002",
+  "INP001",
+  "N999",
+  "PERF203",
+  "PLR0913",
+  "S101",
+  "TD002", "TD003",
+  "TID252",
+  "UP009",
+]
+
+
 [tool.setuptools.dynamic]
 version = {attr = "invenio_edugain.__version__"}
 
 [tool.setuptools.packages]
-find = {}  # use `find` directive to collect packages to be included into distributions
+find = {}


### PR DESCRIPTION
added configuration for:
- `black`
- `isort`
- `ruff`
also added `.editorconfig` for consistent whitespace/indent/encoding between developers