### PR TITLE
change build-backend to `hatchling`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 dynamic = ["version"]
@@ -26,6 +26,10 @@ dependencies = []
 Repository = "https://github.com/tu-graz-library/invenio-edugain"
 
 
+[tool.hatch.version]
+path = "invenio_edugain/__init__.py"
+
+
 [tool.isort]
 profile = "black"
 
@@ -46,10 +50,3 @@ ignore = [
   "TID252",
   "UP009",
 ]
-
-
-[tool.setuptools.dynamic]
-version = {attr = "invenio_edugain.__version__"}
-
-[tool.setuptools.packages]
-find = {}


### PR DESCRIPTION
reasons for this change:
- `hatchling`'s editable installs are recognizable by LSPs
- `setuptools` does some since-standardized things in a legacy way
- we don't need any of `setuptools`'s advanced features